### PR TITLE
Add heartbeat timeout event

### DIFF
--- a/src/main/java/org/jvirtanen/nassau/soupbintcp/SoupBinTCPClient.java
+++ b/src/main/java/org/jvirtanen/nassau/soupbintcp/SoupBinTCPClient.java
@@ -89,7 +89,7 @@ public class SoupBinTCPClient extends SoupBinTCPSession {
                 unexpectedPacketType(PACKET_TYPE_LOGOUT_REQUEST);
             }
 
-        });
+        }, statusListener);
     }
 
     /**

--- a/src/main/java/org/jvirtanen/nassau/soupbintcp/SoupBinTCPClientStatusListener.java
+++ b/src/main/java/org/jvirtanen/nassau/soupbintcp/SoupBinTCPClientStatusListener.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 /**
  * The interface for inbound status events on the client side.
  */
-public interface SoupBinTCPClientStatusListener {
+public interface SoupBinTCPClientStatusListener extends SoupBinTCPSessionStatusListener {
 
     /**
      * Receive a Login Accepted packet.

--- a/src/main/java/org/jvirtanen/nassau/soupbintcp/SoupBinTCPServer.java
+++ b/src/main/java/org/jvirtanen/nassau/soupbintcp/SoupBinTCPServer.java
@@ -89,7 +89,7 @@ public class SoupBinTCPServer extends SoupBinTCPSession {
                 statusListener.logoutRequest();
             }
 
-        });
+        }, statusListener);
     }
 
     /**

--- a/src/main/java/org/jvirtanen/nassau/soupbintcp/SoupBinTCPServerStatusListener.java
+++ b/src/main/java/org/jvirtanen/nassau/soupbintcp/SoupBinTCPServerStatusListener.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 /**
  * The interface for inbound status events on the server side.
  */
-public interface SoupBinTCPServerStatusListener {
+public interface SoupBinTCPServerStatusListener extends SoupBinTCPSessionStatusListener {
 
     /**
      * Receive a Login Request packet.

--- a/src/main/java/org/jvirtanen/nassau/soupbintcp/SoupBinTCPSessionStatusListener.java
+++ b/src/main/java/org/jvirtanen/nassau/soupbintcp/SoupBinTCPSessionStatusListener.java
@@ -1,0 +1,17 @@
+package org.jvirtanen.nassau.soupbintcp;
+
+import java.io.IOException;
+
+/**
+ * An interface for inbound status events on both the client and server side.
+ */
+public interface SoupBinTCPSessionStatusListener {
+
+    /**
+     * Receive an indication of a heartbeat timeout.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    void heartbeatTimeout() throws IOException;
+
+}

--- a/src/test/java/org/jvirtanen/nassau/soupbintcp/SoupBinTCPClientStatus.java
+++ b/src/test/java/org/jvirtanen/nassau/soupbintcp/SoupBinTCPClientStatus.java
@@ -1,5 +1,7 @@
 package org.jvirtanen.nassau.soupbintcp;
 
+import static org.jvirtanen.nassau.soupbintcp.SoupBinTCPSessionStatus.*;
+
 import java.util.ArrayList;
 import java.util.List;
 import org.jvirtanen.value.Value;
@@ -29,6 +31,11 @@ class SoupBinTCPClientStatus implements SoupBinTCPClientStatusListener {
     @Override
     public void endOfSession() {
         events.add(new EndOfSession());
+    }
+
+    @Override
+    public void heartbeatTimeout() {
+        events.add(new HeartbeatTimeout());
     }
 
     public interface Event {

--- a/src/test/java/org/jvirtanen/nassau/soupbintcp/SoupBinTCPServerStatus.java
+++ b/src/test/java/org/jvirtanen/nassau/soupbintcp/SoupBinTCPServerStatus.java
@@ -1,5 +1,7 @@
 package org.jvirtanen.nassau.soupbintcp;
 
+import static org.jvirtanen.nassau.soupbintcp.SoupBinTCPSessionStatus.*;
+
 import java.util.ArrayList;
 import java.util.List;
 import org.jvirtanen.value.Value;
@@ -25,6 +27,11 @@ class SoupBinTCPServerStatus implements SoupBinTCPServerStatusListener {
     @Override
     public void logoutRequest() {
         events.add(new LogoutRequest());
+    }
+
+    @Override
+    public void heartbeatTimeout() {
+        events.add(new HeartbeatTimeout());
     }
 
     public interface Event {

--- a/src/test/java/org/jvirtanen/nassau/soupbintcp/SoupBinTCPSessionStatus.java
+++ b/src/test/java/org/jvirtanen/nassau/soupbintcp/SoupBinTCPSessionStatus.java
@@ -1,0 +1,11 @@
+package org.jvirtanen.nassau.soupbintcp;
+
+import org.jvirtanen.value.Value;
+
+class SoupBinTCPSessionStatus {
+
+    public static class HeartbeatTimeout extends Value
+            implements SoupBinTCPClientStatus.Event, SoupBinTCPServerStatus.Event {
+    }
+
+}

--- a/src/test/java/org/jvirtanen/nassau/soupbintcp/SoupBinTCPSessionTest.java
+++ b/src/test/java/org/jvirtanen/nassau/soupbintcp/SoupBinTCPSessionTest.java
@@ -4,6 +4,7 @@ import static java.util.Arrays.*;
 import static org.junit.Assert.*;
 import static org.jvirtanen.nassau.soupbintcp.SoupBinTCPClientStatus.*;
 import static org.jvirtanen.nassau.soupbintcp.SoupBinTCPServerStatus.*;
+import static org.jvirtanen.nassau.soupbintcp.SoupBinTCPSessionStatus.*;
 import static org.jvirtanen.nassau.util.Strings.*;
 
 import java.nio.channels.ServerSocketChannel;
@@ -217,9 +218,9 @@ public class SoupBinTCPSessionTest {
 
         clock.setCurrentTimeMillis(16750);
 
-        exception.expect(SoupBinTCPException.class);
-
         server.keepAlive();
+
+        assertEquals(asList(new HeartbeatTimeout()), serverStatus.collect());
     }
 
     @Test
@@ -237,9 +238,9 @@ public class SoupBinTCPSessionTest {
 
         clock.setCurrentTimeMillis(16750);
 
-        exception.expect(SoupBinTCPException.class);
-
         client.keepAlive();
+
+        assertEquals(asList(new HeartbeatTimeout()), clientStatus.collect());
     }
 
     private String message(int length) {


### PR DESCRIPTION
Instead of throwing an exception on heartbeat timeout, invoke an appropriate method on the status listener.
