### PR TITLE
Fix BinaryFILE reader interface

### DIFF
--- a/nassau-binaryfile-perf-test/src/main/java/com/paritytrading/nassau/binaryfile/perf/PerfTest.java
+++ b/nassau-binaryfile-perf-test/src/main/java/com/paritytrading/nassau/binaryfile/perf/PerfTest.java
@@ -32,7 +32,7 @@ class PerfTest {
 
         long started = System.nanoTime();
 
-        while (reader.read());
+        while (reader.read() >= 0);
 
         long finished = System.nanoTime();
 

--- a/nassau/src/test/java/com/paritytrading/nassau/binaryfile/BinaryFILEReaderTest.java
+++ b/nassau/src/test/java/com/paritytrading/nassau/binaryfile/BinaryFILEReaderTest.java
@@ -33,7 +33,7 @@ public class BinaryFILEReaderTest {
     public void readStream() throws Exception {
         BinaryFILEReader reader = new BinaryFILEReader(stream, messages);
 
-        while (reader.read());
+        while (reader.read() >= 0);
 
         assertEquals(asList("foo", "bar", "baz", "quux", ""), messages.collect());
     }
@@ -46,7 +46,7 @@ public class BinaryFILEReaderTest {
 
         BinaryFILEReader reader = new BinaryFILEReader(stream, parser);
 
-        while (reader.read());
+        while (reader.read() >= 0);
 
         assertEquals(asList("foo", "bar", "baz", "quux"), messages.collect());
         assertEquals(asList(new EndOfSession()), status.collect());


### PR DESCRIPTION
Read from the channel once per method invocation, and parse all messages in the buffer. Return the number of bytes read, or `-1` if the channel has reached end-of-stream.

This aligns the BinaryFILE implementation with the MoldUDP64 and SoupBinTCP implementations and fixes #35.