### PR TITLE
Improve BinaryFILE write performance

### DIFF
--- a/nassau/src/main/java/com/paritytrading/nassau/binaryfile/BinaryFILEWriter.java
+++ b/nassau/src/main/java/com/paritytrading/nassau/binaryfile/BinaryFILEWriter.java
@@ -4,40 +4,40 @@ import static com.paritytrading.foundation.ByteBuffers.*;
 
 import java.io.Closeable;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
+import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
-import java.nio.channels.WritableByteChannel;
+import java.nio.channels.FileChannel;
 
 /**
  * An implementation of a BinaryFILE writer.
  */
 public class BinaryFILEWriter implements Closeable {
 
-    private WritableByteChannel channel;
+    private static final long DEFAULT_SIZE = 128 * 1024 * 1024;
 
-    private ByteBuffer header;
+    private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);
 
-    /**
-     * Create a BinaryFILE writer.
-     *
-     * @param stream an output stream
-     */
-    public BinaryFILEWriter(OutputStream stream) {
-        this(Channels.newChannel(stream));
-    }
+    private RandomAccessFile file;
 
-    /**
-     * Create a BinaryFILE writer.
-     *
-     * @param channel an output channel
-     */
-    public BinaryFILEWriter(WritableByteChannel channel) {
-        this.channel = channel;
+    private FileChannel channel;
 
-        this.header = ByteBuffer.allocate(2);
+    private long size;
+
+    private long position;
+
+    private ByteBuffer buffer;
+
+    private BinaryFILEWriter(RandomAccessFile file, long size) {
+        this.file = file;
+
+        this.channel = file.getChannel();
+
+        this.size = size;
+
+        this.position = 0;
+
+        this.buffer = EMPTY_BUFFER;
     }
 
     /**
@@ -48,9 +48,19 @@ public class BinaryFILEWriter implements Closeable {
      * @throws IOException if an I/O error occurs
      */
     public static BinaryFILEWriter open(File file) throws IOException {
-        FileOutputStream stream = new FileOutputStream(file);
+        return open(file, DEFAULT_SIZE);
+    }
 
-        return new BinaryFILEWriter(stream.getChannel());
+    /**
+     * Open a BinaryFILE writer.
+     *
+     * @param file the output file
+     * @param size the size of the memory-mapped region
+     * @return a BinaryFILE writer
+     * @throws IOException if an I/O error occurs
+     */
+    public static BinaryFILEWriter open(File file, long size) throws IOException {
+        return new BinaryFILEWriter(new RandomAccessFile(file, "rw"), size);
     }
 
     /**
@@ -60,22 +70,24 @@ public class BinaryFILEWriter implements Closeable {
      * @throws IOException if an I/O error occurs
      */
     public void write(ByteBuffer payload) throws IOException {
-        header.clear();
-        putUnsignedShort(header, payload.remaining());
-        header.flip();
+        if (buffer.remaining() < 2 + payload.remaining())
+            map();
 
-        do {
-            channel.write(header);
-        } while (header.hasRemaining());
-
-        do {
-            channel.write(payload);
-        } while (payload.hasRemaining());
+        putUnsignedShort(buffer, payload.remaining());
+        buffer.put(payload);
     }
 
     @Override
     public void close() throws IOException {
-        channel.close();
+        file.setLength(position + buffer.position());
+
+        file.close();
+    }
+
+    private void map() throws IOException {
+        position += buffer.position();
+
+        buffer = channel.map(FileChannel.MapMode.READ_WRITE, position, size);
     }
 
 }

--- a/nassau/src/main/java/com/paritytrading/nassau/binaryfile/BinaryFILEWriter.java
+++ b/nassau/src/main/java/com/paritytrading/nassau/binaryfile/BinaryFILEWriter.java
@@ -10,7 +10,6 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
-import java.util.zip.GZIPOutputStream;
 
 /**
  * An implementation of a BinaryFILE writer.
@@ -51,10 +50,7 @@ public class BinaryFILEWriter implements Closeable {
     public static BinaryFILEWriter open(File file) throws IOException {
         FileOutputStream stream = new FileOutputStream(file);
 
-        if (file.getName().endsWith(".gz"))
-            return new BinaryFILEWriter(new GZIPOutputStream(stream, 65536));
-        else
-            return new BinaryFILEWriter(stream.getChannel());
+        return new BinaryFILEWriter(stream.getChannel());
     }
 
     /**
@@ -67,9 +63,6 @@ public class BinaryFILEWriter implements Closeable {
         header.clear();
         putUnsignedShort(header, payload.remaining());
         header.flip();
-
-        // Unfortunately there is no way to get a GatheringByteChannel from a
-        // GZIPOutputStream.
 
         do {
             channel.write(header);

--- a/nassau/src/test/java/com/paritytrading/nassau/binaryfile/BinaryFILEWriterTest.java
+++ b/nassau/src/test/java/com/paritytrading/nassau/binaryfile/BinaryFILEWriterTest.java
@@ -4,7 +4,7 @@ import static com.paritytrading.nassau.Strings.*;
 import static java.util.Arrays.*;
 import static org.junit.Assert.*;
 
-import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
@@ -14,16 +14,18 @@ public class BinaryFILEWriterTest {
 
     @Test
     public void write() throws Exception {
-        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        File file = File.createTempFile("binaryfile", ".dat");
 
-        BinaryFILEWriter writer = new BinaryFILEWriter(stream);
+        BinaryFILEWriter writer = BinaryFILEWriter.open(file);
 
         List<String> messages = asList("foo", "bar", "baz", "quux", "");
 
         for (String message : messages)
             writer.write(wrap(message));
 
-        byte[] writtenBytes  = stream.toByteArray();
+        writer.close();
+
+        byte[] writtenBytes  = Files.readAllBytes(file.toPath());
         byte[] expectedBytes = Files.readAllBytes(Paths.get(getClass().getResource("/binaryfile.dat").toURI()));
 
         assertArrayEquals(expectedBytes, writtenBytes);

--- a/nassau/src/test/java/com/paritytrading/nassau/binaryfile/BinaryFILEWriterTest.java
+++ b/nassau/src/test/java/com/paritytrading/nassau/binaryfile/BinaryFILEWriterTest.java
@@ -5,7 +5,8 @@ import static java.util.Arrays.*;
 import static org.junit.Assert.*;
 
 import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import org.junit.Test;
 
@@ -23,20 +24,9 @@ public class BinaryFILEWriterTest {
             writer.write(wrap(message));
 
         byte[] writtenBytes  = stream.toByteArray();
-        byte[] expectedBytes = toByteArray(getClass().getResourceAsStream("/binaryfile.dat"));
+        byte[] expectedBytes = Files.readAllBytes(Paths.get(getClass().getResource("/binaryfile.dat").toURI()));
 
         assertArrayEquals(expectedBytes, writtenBytes);
-    }
-
-    private byte[] toByteArray(InputStream input) throws Exception {
-        ByteArrayOutputStream output = new ByteArrayOutputStream();
-
-        int b;
-
-        while ((b = input.read()) != -1)
-            output.write(b);
-
-        return output.toByteArray();
     }
 
 }

--- a/nassau/src/test/java/com/paritytrading/nassau/binaryfile/BinaryFILEWriterTest.java
+++ b/nassau/src/test/java/com/paritytrading/nassau/binaryfile/BinaryFILEWriterTest.java
@@ -1,6 +1,5 @@
 package com.paritytrading.nassau.binaryfile;
 
-import static com.paritytrading.nassau.binaryfile.BinaryFILEStatus.*;
 import static com.paritytrading.nassau.Strings.*;
 import static java.util.Arrays.*;
 import static org.junit.Assert.*;


### PR DESCRIPTION
Use memory mapping to improve throughput while working with large files.