### PR TITLE
Improve support for requested initial sequence number in MoldUDP64 client

### DIFF
--- a/applications/binaryfile-recorder/src/main/java/com/paritytrading/nassau/binaryfile/recorder/Recorder.java
+++ b/applications/binaryfile-recorder/src/main/java/com/paritytrading/nassau/binaryfile/recorder/Recorder.java
@@ -151,7 +151,7 @@ class Recorder {
             }
 
             @Override
-            public void downstream(MoldUDP64Client session) {
+            public void downstream(MoldUDP64Client session, long sequenceNumber, int messageCount) {
             }
 
             @Override

--- a/applications/soupbintcp-gateway/src/main/java/com/paritytrading/nassau/soupbintcp/gateway/UpstreamFactory.java
+++ b/applications/soupbintcp-gateway/src/main/java/com/paritytrading/nassau/soupbintcp/gateway/UpstreamFactory.java
@@ -54,7 +54,7 @@ class UpstreamFactory {
             }
 
             @Override
-            public void downstream(MoldUDP64Client session) {
+            public void downstream(MoldUDP64Client session, long sequenceNumber, int messageCount) {
             }
 
             @Override

--- a/libraries/core/src/main/java/com/paritytrading/nassau/moldudp64/MoldUDP64Client.java
+++ b/libraries/core/src/main/java/com/paritytrading/nassau/moldudp64/MoldUDP64Client.java
@@ -285,20 +285,14 @@ public class MoldUDP64Client implements Closeable {
             } else {
                 long skipUntilSequenceNumber = Math.min(nextSequenceNumber, nextExpectedSequenceNumber);
 
-                while (sequenceNumber < skipUntilSequenceNumber) {
+                for (long s = sequenceNumber; s < skipUntilSequenceNumber; s++)
                     skip();
 
-                    sequenceNumber++;
-                }
-
-                while (nextExpectedSequenceNumber < nextSequenceNumber) {
+                for (; nextExpectedSequenceNumber < nextSequenceNumber; nextExpectedSequenceNumber++)
                     read();
-
-                    nextExpectedSequenceNumber++;
-                }
             }
 
-            statusListener.downstream(this);
+            statusListener.downstream(this, sequenceNumber, messageCount);
         }
     }
 

--- a/libraries/core/src/main/java/com/paritytrading/nassau/moldudp64/MoldUDP64Client.java
+++ b/libraries/core/src/main/java/com/paritytrading/nassau/moldudp64/MoldUDP64Client.java
@@ -71,7 +71,7 @@ public class MoldUDP64Client implements Closeable {
 
         this.session = new byte[SESSION_LENGTH];
 
-        this.nextExpectedSequenceNumber = Math.max(1, requestedSequenceNumber);
+        this.nextExpectedSequenceNumber = Math.max(0, requestedSequenceNumber);
 
         this.requestUntilSequenceNumber = REQUEST_UNTIL_SEQUENCE_NUMBER_UNKNOWN;
 
@@ -100,6 +100,9 @@ public class MoldUDP64Client implements Closeable {
      * Create a MoldUDP64 client. Use the underlying datagram channel both for
      * receiving downstream packets and sending request packets. The underlying
      * datagram channel can be either blocking or non-blocking.
+     *
+     * <p>Set the requested initial sequence number to 0 to start from the
+     * first received message.</p>
      *
      * @param channel the underlying datagram channel
      * @param requestAddress the request address
@@ -140,6 +143,9 @@ public class MoldUDP64Client implements Closeable {
      * channel for sending request packets. Both the underlying datagram
      * channel and the underlying request datagram channel must be
      * non-blocking.
+     *
+     * <p>Set the requested initial sequence number to 0 to start from the
+     * first received message.</p>
      *
      * @param channel the underlying datagram channel
      * @param requestChannel the underlying request datagram channel
@@ -236,6 +242,9 @@ public class MoldUDP64Client implements Closeable {
             messageCount = 0;
 
         long nextSequenceNumber = sequenceNumber + messageCount;
+
+        if (nextExpectedSequenceNumber == 0)
+            nextExpectedSequenceNumber = sequenceNumber;
 
         if (sequenceNumber > nextExpectedSequenceNumber) {
             if (requestUntilSequenceNumber == REQUEST_UNTIL_SEQUENCE_NUMBER_UNKNOWN) {

--- a/libraries/core/src/main/java/com/paritytrading/nassau/moldudp64/MoldUDP64Client.java
+++ b/libraries/core/src/main/java/com/paritytrading/nassau/moldudp64/MoldUDP64Client.java
@@ -42,7 +42,7 @@ public class MoldUDP64Client implements Closeable {
 
     private byte[] session;
 
-    private long nextExpectedSequenceNumber;
+    protected long nextExpectedSequenceNumber;
 
     private long requestUntilSequenceNumber;
 

--- a/libraries/core/src/main/java/com/paritytrading/nassau/moldudp64/MoldUDP64ClientStatusListener.java
+++ b/libraries/core/src/main/java/com/paritytrading/nassau/moldudp64/MoldUDP64ClientStatusListener.java
@@ -20,9 +20,12 @@ public interface MoldUDP64ClientStatusListener {
      * Indicates that a downstream packet was processed successfully.
      *
      * @param session the session
+     * @param sequenceNumber the sequence number
+     * @param messageCount the message count
      * @throws IOException if an I/O error occurs
      */
-    void downstream(MoldUDP64Client session) throws IOException;
+    void downstream(MoldUDP64Client session, long sequenceNumber,
+            int messageCount) throws IOException;
 
     /**
      * Indicates that a request packet was sent.

--- a/libraries/core/src/test/java/com/paritytrading/nassau/moldudp64/MoldUDP64ClientStatus.java
+++ b/libraries/core/src/test/java/com/paritytrading/nassau/moldudp64/MoldUDP64ClientStatus.java
@@ -22,8 +22,8 @@ class MoldUDP64ClientStatus implements MoldUDP64ClientStatusListener {
     }
 
     @Override
-    public void downstream(MoldUDP64Client session) {
-        events.add(new Downstream());
+    public void downstream(MoldUDP64Client session, long sequenceNumber, int messageCount) {
+        events.add(new Downstream(sequenceNumber, messageCount));
     }
 
     @Override
@@ -48,6 +48,13 @@ class MoldUDP64ClientStatus implements MoldUDP64ClientStatusListener {
     }
 
     public static class Downstream extends Value implements Event {
+        public final long sequenceNumber;
+        public final int  messageCount;
+
+        public Downstream(long sequenceNumber, int messageCount) {
+            this.sequenceNumber = sequenceNumber;
+            this.messageCount   = messageCount;
+        }
     }
 
     public static class Request extends Value implements Event {

--- a/libraries/core/src/test/java/com/paritytrading/nassau/moldudp64/MoldUDP64SessionTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/nassau/moldudp64/MoldUDP64SessionTest.java
@@ -440,4 +440,31 @@ public class MoldUDP64SessionTest {
                     new Downstream()), clientStatus.collect());
     }
 
+    @Test
+    public void firstReceivedMessage() throws Exception {
+        List<String> messages = asList("foo", "bar");
+
+        client.nextExpectedSequenceNumber = 0;
+
+        packet.clear();
+        packet.put(wrap("foo"));
+
+        server.nextSequenceNumber = 3;
+        server.send(packet);
+
+        client.receive();
+
+        packet.clear();
+        packet.put(wrap("bar"));
+
+        server.nextSequenceNumber = 4;
+        server.send(packet);
+
+        client.receive();
+
+        assertEquals(messages, clientMessages.collect());
+        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(),
+                    new Downstream()), clientStatus.collect());
+    }
+
 }

--- a/libraries/core/src/test/java/com/paritytrading/nassau/moldudp64/MoldUDP64SessionTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/nassau/moldudp64/MoldUDP64SessionTest.java
@@ -413,4 +413,31 @@ public class MoldUDP64SessionTest {
                 clientStatus.collect());
     }
 
+    @Test
+    public void requestedSequenceNumber() throws Exception {
+        List<String> messages = asList("bar");
+
+        client.nextExpectedSequenceNumber = 4;
+
+        packet.clear();
+        packet.put(wrap("foo"));
+
+        server.nextSequenceNumber = 3;
+        server.send(packet);
+
+        client.receive();
+
+        packet.clear();
+        packet.put(wrap("bar"));
+
+        server.nextSequenceNumber = 4;
+        server.send(packet);
+
+        client.receive();
+
+        assertEquals(messages, clientMessages.collect());
+        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(),
+                    new Downstream()), clientStatus.collect());
+    }
+
 }

--- a/libraries/core/src/test/java/com/paritytrading/nassau/moldudp64/MoldUDP64SessionTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/nassau/moldudp64/MoldUDP64SessionTest.java
@@ -91,7 +91,7 @@ public class MoldUDP64SessionTest {
         client.receive();
 
         assertEquals(asList("foo"), clientMessages.collect());
-        assertEquals(asList(new State(SYNCHRONIZED), new Downstream()),
+        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(1, 1)),
                 clientStatus.collect());
     }
 
@@ -106,7 +106,7 @@ public class MoldUDP64SessionTest {
         client.receive();
 
         assertEquals(asList("foo", "bar"), clientMessages.collect());
-        assertEquals(asList(new State(SYNCHRONIZED), new Downstream()),
+        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(1, 2)),
                 clientStatus.collect());
     }
 
@@ -117,7 +117,7 @@ public class MoldUDP64SessionTest {
         client.receive();
 
         assertEquals(emptyList(), clientMessages.collect());
-        assertEquals(asList(new State(SYNCHRONIZED), new Downstream()),
+        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(1, 0)),
                 clientStatus.collect());
     }
 
@@ -128,7 +128,7 @@ public class MoldUDP64SessionTest {
         client.receive();
 
         assertEquals(emptyList(), clientMessages.collect());
-        assertEquals(asList(new State(SYNCHRONIZED), new EndOfSession(), new Downstream()),
+        assertEquals(asList(new State(SYNCHRONIZED), new EndOfSession(), new Downstream(1, 0)),
                 clientStatus.collect());
     }
 
@@ -154,8 +154,8 @@ public class MoldUDP64SessionTest {
             client.receive();
 
         assertEquals(emptyList(), clientMessages.collect());
-        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(),
-                    new Downstream()), clientStatus.collect());
+        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(1, 0),
+                    new Downstream(1, 0)), clientStatus.collect());
     }
 
     @Test
@@ -169,7 +169,7 @@ public class MoldUDP64SessionTest {
         client.receive();
 
         assertEquals(asList(message), clientMessages.collect());
-        assertEquals(asList(new State(SYNCHRONIZED), new Downstream()),
+        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(1, 1)),
                 clientStatus.collect());
     }
 
@@ -198,7 +198,7 @@ public class MoldUDP64SessionTest {
 
         assertEquals(messages, clientMessages.collect());
         assertEquals(asList(new State(BACKFILL), new Request(1, 3),
-                    new State(SYNCHRONIZED), new Downstream()),
+                    new State(SYNCHRONIZED), new Downstream(1, 3)),
                 clientStatus.collect());
     }
 
@@ -224,9 +224,9 @@ public class MoldUDP64SessionTest {
         client.receiveResponse();
 
         assertEquals(messages, clientMessages.collect());
-        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(),
+        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(1, 0),
                     new State(GAP_FILL), new Request(1, 3),
-                    new State(SYNCHRONIZED), new Downstream()),
+                    new State(SYNCHRONIZED), new Downstream(1, 3)),
                 clientStatus.collect());
     }
 
@@ -265,10 +265,10 @@ public class MoldUDP64SessionTest {
         client.receiveResponse();
 
         assertEquals(messages, clientMessages.collect());
-        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(),
+        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(1, 0),
                     new State(GAP_FILL), new Request(1, 1),
-                    new Request(2, 2), new Downstream(),
-                    new State(SYNCHRONIZED), new Downstream()),
+                    new Request(2, 2), new Downstream(1, 1),
+                    new State(SYNCHRONIZED), new Downstream(2, 2)),
                 clientStatus.collect());
     }
 
@@ -294,9 +294,9 @@ public class MoldUDP64SessionTest {
         client.receiveResponse();
 
         assertEquals(messages, clientMessages.collect());
-        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(),
+        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(1, 0),
                     new State(GAP_FILL), new Request(1, 3),
-                    new State(SYNCHRONIZED), new Downstream()),
+                    new State(SYNCHRONIZED), new Downstream(1, 3)),
                 clientStatus.collect());
     }
 
@@ -337,10 +337,10 @@ public class MoldUDP64SessionTest {
         client.receiveResponse();
 
         assertEquals(messages, clientMessages.collect());
-        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(),
+        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(1, 0),
                     new State(GAP_FILL), new Request(1, 2),
                     new Request(1, 3), new State(SYNCHRONIZED),
-                    new Downstream()), clientStatus.collect());
+                    new Downstream(1, 3)), clientStatus.collect());
     }
 
     @Test
@@ -373,8 +373,8 @@ public class MoldUDP64SessionTest {
         client.receive();
 
         assertEquals(messages, clientMessages.collect());
-        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(),
-                    new Downstream(), new Downstream()),
+        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(1, 1),
+                    new Downstream(1, 2), new Downstream(3, 1)),
                 clientStatus.collect());
     }
 
@@ -408,8 +408,8 @@ public class MoldUDP64SessionTest {
         client.receive();
 
         assertEquals(messages, clientMessages.collect());
-        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(),
-                    new Downstream(), new Downstream()),
+        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(1, 1),
+                    new Downstream(1, 1), new Downstream(2, 2)),
                 clientStatus.collect());
     }
 
@@ -436,8 +436,8 @@ public class MoldUDP64SessionTest {
         client.receive();
 
         assertEquals(messages, clientMessages.collect());
-        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(),
-                    new Downstream()), clientStatus.collect());
+        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(3, 1),
+                    new Downstream(4, 1)), clientStatus.collect());
     }
 
     @Test
@@ -463,8 +463,8 @@ public class MoldUDP64SessionTest {
         client.receive();
 
         assertEquals(messages, clientMessages.collect());
-        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(),
-                    new Downstream()), clientStatus.collect());
+        assertEquals(asList(new State(SYNCHRONIZED), new Downstream(3, 1),
+                    new Downstream(4, 1)), clientStatus.collect());
     }
 
 }

--- a/libraries/util/src/main/java/com/paritytrading/nassau/util/MoldUDP64.java
+++ b/libraries/util/src/main/java/com/paritytrading/nassau/util/MoldUDP64.java
@@ -80,7 +80,7 @@ public class MoldUDP64 {
         }
 
         @Override
-        public void downstream(MoldUDP64Client session) {
+        public void downstream(MoldUDP64Client session, long sequenceNumber, int messageCount) {
         }
 
         @Override


### PR DESCRIPTION
Make it possible to start from the first received message, mirroring the last generated message in SoupBinTCP.