### PR TITLE
Fix 'maven-shade-plugin' configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
           <version>3.3.0</version>
+          <configuration>
+            <createDependencyReducedPom>false</createDependencyReducedPom>
+          </configuration>
           <executions>
             <execution>
               <phase>package</phase>


### PR DESCRIPTION
The plugin behavior has changed between the previously used version, 3.2.4, and the currently used version, 3.3.0.